### PR TITLE
Fix parameter name check in `MethodInfo`.

### DIFF
--- a/src/mino/structure/MethodInfo.java
+++ b/src/mino/structure/MethodInfo.java
@@ -42,6 +42,7 @@ public abstract class MethodInfo {
                 throw new InterpreterException("duplicate parameter " + name,
                         id);
             }
+            paramNameSet.add(name);
             this.paramNames.add(name);
         }
     }


### PR DESCRIPTION
Duplicate parameters name were never detected because the collection used to do this was left empty.
